### PR TITLE
Change `coiled-team-account` to `coiled-account`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a robust dataset for exploration.  Unfortunately, while it is provided a
 ### Getting Started
 This repo assumed you have a Coiled account, a Prefect account, are familiar with the following concepts, and have access to the following access credentials:
 
-- Coiled Accounts, Teams, and Tokens 
+- Coiled Users, Teams, and Tokens 
 - Prefect Cloud
 - Prefect Flows and Tasks
 - Prefect Blocks
@@ -33,7 +33,7 @@ This repo assumed you have a Coiled account, a Prefect account, are familiar wit
 
 
 1.  Clone this repository
-2.  In Prefect, store your credentials to create a `Coiled` cluster as `Prefect Blocks`.  Here we store them as:  `coiled-account`, `coiled-team-account`, and `coiled-token`.
+2.  In Prefect, store your credentials to create a `Coiled` cluster as `Prefect Blocks`.  Here we store them as:  `coiled-user`, `coiled-account` (your team), and `coiled-token`.
 3.  In Prefect, store your credentials to authenticate to your private S3 bucket as a `Prefect AwsCredentials`.  Here, we label it `prefectexample0`
 
 

--- a/flows/coiled_flow.py
+++ b/flows/coiled_flow.py
@@ -108,7 +108,7 @@ def log_summary(x):
         cluster_class="coiled.Cluster",
         cluster_kwargs={
             "n_workers": 10,
-            "account": Secret.load("coiled-team-account").get(),
+            "account": Secret.load("coiled-account").get(),
             "name": f"nyc-taxi-uber-lyft-{str(uuid.uuid1())}",
             "backend_options": {"region": "us-east-1"},
             "worker_memory": "64 GiB",


### PR DESCRIPTION
@hayesgb suggestion to change the naming here to match the [blog post](https://github.com/coiled/coiled.github.io/blob/f1aa7cd8eee6b3c25fde8d98e17e7d878fb07750/blog/coiled-from-prefect.md?plain=1#L47)
